### PR TITLE
Use versionless compose format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .


### PR DESCRIPTION
## Summary
- remove obsolete `version` from compose file

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844102422308328a98132efaa9b9136